### PR TITLE
Add support for defining parameters on scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,22 @@ Rename the `magic-cli` script to whatever you want — for example, if you happe
 
 Now, when you run `example`, it will look for executables in the same directory as itself which have filenames that begin with `example-`. If there's an executable called `example-build`, you could run it by typing `example build`.
 
-Now, when you type `example`, you'll see `example build` in the list of supported subcommands. For extra credit, you can add a human-readable description in that list by putting a comment immediately under the `#!` line:
+Now, when you type `example`, you'll see `example build` in the list of supported subcommands. 
+
+For extra credit, you can add a human-readable description in that list by putting a comment immediately under the `#!` line:
 
 ````bash
 #!/usr/bin/env bash
 # This line will be shown in the list of commands.
+````
+
+You can also define any extra parameters that are required for the script with a `# @param` line for each parameter:
+
+````bash
+#!/usr/bin/env bash
+# This line will be shown in the list of commands.
+# @param <command_param> - Longer Description of the Parameter
+# @param - If you don’t give a parameter name, a default one will be created for you
 ````
 
 ## Installation

--- a/magic-cli
+++ b/magic-cli
@@ -16,10 +16,11 @@ class MagicCli
         subcommands = []
         @commands.each do |filename|
             description = self.get_description(filename)
+            parameters = self.get_parameters(filename).join(" ")
             # Remove the `BASENAME-` PREFIX from the filename to get the name of the subcommand
             subcommand = File.basename(filename)[(BASENAME.size + 1)..-1]
             subcommands.push({
-                :name => subcommand,
+                :name => [subcommand, parameters].join(" "),
                 :description => description
             })
         end
@@ -43,6 +44,20 @@ class MagicCli
         return description
     end
 
+    def get_parameters(filename)
+      # Optionally, retrieve parameters that are required
+      lines = File.readlines(filename)
+      parameters = lines.map do |line|
+        if line.strip.start_with?('# @param')
+          line = line.strip.sub(/^# @param\s*/, '').sub(/-.*$/, '').strip
+          line = "<param>" if line.empty?
+          line
+        else
+          nil
+        end
+      end.compact
+      return parameters
+    end
 
     def execute(command, args)
         executable = File.join(COMMAND_DIR, PREFIX + command)

--- a/magic-cli
+++ b/magic-cli
@@ -47,7 +47,8 @@ class MagicCli
     def get_parameters(filename)
       # Optionally, retrieve parameters that are required
       lines = File.readlines(filename)
-      parameters = lines.map do |line|
+      header = lines.take_while{|l| l.strip.start_with?('#')}
+      parameters = header.map do |line|
         if line.strip.start_with?('# @param')
           line = line.strip.sub(/^# @param\s*/, '').sub(/-.*$/, '').strip
           line = "<param>" if line.empty?

--- a/magic-cli-example
+++ b/magic-cli-example
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
 #Just a simple example command.
+# @param <random> - Random Parameter 1
+# @param - Random Parameter 2
 
-puts "It worked! 🎩✨"
+puts "It worked! 🎩✨" + ARGV.join(" ")

--- a/magic-cli-example
+++ b/magic-cli-example
@@ -3,4 +3,9 @@
 # @param <random> - Random Parameter 1
 # @param - Random Parameter 2
 
-puts "It worked! 🎩✨" + ARGV.join(" ")
+def result(foo)
+  # @param <foo>
+  puts "It worked! 🎩✨ " + foo
+end
+
+result(ARGV.join(" "))


### PR DESCRIPTION
Some of our scripts take extra parameters. It is nice to be able to know the ones for which this is the case.

**_magic-cli-example**_

```
#!/usr/bin/env ruby
#Just a simple example command.
# @param <random> - Random Parameter 1
# @param - Random Parameter 2

puts "It worked! 🎩✨" + ARGV.join(" ")
```

**Output**

```
╰─ ./magic-cli
usage: magic-cli <command> [<args>]

Commands:
   example <random> <param>   Just a simple example command.
   update                     Installs the latest version of these tools.
```
